### PR TITLE
accept a params object, a swal function, or nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following options can be React elements:
 const swal = require('sweetalert2')
 const withReactContent = require('sweetalert2-react-content')
 
-const mySwal = withReactContent({ swal })
+const mySwal = withReactContent(swal)
 // or just `const mySwal = withReactContent()`
 
 mySwal({

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # TODO
 
 - put build test (test-build.html) in automated harness
-- enable greenkeeper
 
 (also search "TODO" in code)

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,12 @@ const { mounts } = require('./mounts')
 
 const noop = () => {}
 
-function sweetalert2ReactContent({ swal = require('sweetalert2') } = {}) {
+function sweetalert2ReactContent(arg) {
+  const options =
+    typeof arg === 'object'
+      ? arg
+      : { swal: typeof arg === 'function' ? arg : require('sweetalert2') }
+  const { swal } = options
   const fn = (...args) => {
     const params = Object.assign({}, toParams(args)) // safe to mutate this
 

--- a/tests/units/main.js
+++ b/tests/units/main.js
@@ -66,7 +66,7 @@ describe('sweetalert2-react-content', () => {
       return { value: 'bar' }
     }
     Object.assign(mockSwal, swal)
-    const mySwal = withReactContent({ swal: mockSwal })
+    const mySwal = withReactContent(mockSwal)
     const result = await mySwal({ title: 'foo' })
     expect(result).toEqual({ value: 'bar' })
   })

--- a/tests/units/main.js
+++ b/tests/units/main.js
@@ -65,8 +65,9 @@ describe('sweetalert2-react-content', () => {
       expect(params.title).toEqual('foo')
       return { value: 'bar' }
     }
-    Object.assign(mockSwal, swal)
+    Object.assign(mockSwal, swal, { method: () => {} })
     const mySwal = withReactContent(mockSwal)
+    expect(mySwal.method).toEqual(mockSwal.method)
     const result = await mySwal({ title: 'foo' })
     expect(result).toEqual({ value: 'bar' })
   })


### PR DESCRIPTION
Opening this PR to test out the workflow with Travis, Coveralls, semantic-release & Greenkeeper